### PR TITLE
Optional permissions

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -2,8 +2,12 @@ console.log('background script')
 
 console.log('my extension...')
 
-function useNotificationsApi() {
-  console.log('notifications enabled', 'notifications' in browser)
+async function useNotificationsApi() {
+  console.log('notifications api present', 'notifications' in browser)
+  console.log(
+    'notifications enabled',
+    await browser.permissions.contains({ permissions: ['notifications'] }),
+  )
 
   browser.notifications?.onClicked.addListener(function (notificationId) {
     console.log(notificationId)

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,10 +1,20 @@
 console.log('background script')
 
+console.log('my extension...')
 
+function useNotificationsApi() {
+  console.log('notifications enabled', 'notifications' in browser)
 
-console.log('my extension...');
+  browser.notifications?.onClicked.addListener(function (notificationId) {
+    console.log(notificationId)
+  })
+}
 
-browser.notifications.onClicked.addListener(function (notificationId) {
+useNotificationsApi()
 
- console.log(notificationId)
+browser.permissions.onAdded.addListener(() => {
+  useNotificationsApi()
 })
+
+// to enable top-level await
+export {}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "background": { "scripts": ["background/index.ts"] },
+  "background": { "scripts": ["background/index.ts"], "persistent": false },
   "content_scripts": [
     {
       "js": ["content/index.ts"],

--- a/src/pages/popup/App.tsx
+++ b/src/pages/popup/App.tsx
@@ -4,7 +4,13 @@ const App = (): JSX.Element => {
   return (
     <div>
       <h1>Popup Page</h1>
-      <p>If you are seeing this, React is working!</p>
+      <button
+        onClick={() => {
+          chrome.permissions.request({ permissions: ['notifications'] })
+        }}
+      >
+        Enable notifications
+      </button>
     </div>
   )
 }

--- a/src/pages/popup/App.tsx
+++ b/src/pages/popup/App.tsx
@@ -6,7 +6,8 @@ const App = (): JSX.Element => {
       <h1>Popup Page</h1>
       <button
         onClick={() => {
-          chrome.permissions.request({ permissions: ['notifications'] })
+          // Permissions request must be made from a user gesture.
+          browser.permissions.request({ permissions: ['notifications'] })
         }}
       >
         Enable notifications


### PR DESCRIPTION
Hey @rustyzone, great to hear from you! Optional permissions are a bit tricky. 

If a permission is optional, then the associated API will be undefined until it is requested using `browser.permissions.request`. I've included a naive example in this PR, hope it helps!